### PR TITLE
simplified addItem / sorry, branch renamed

### DIFF
--- a/src/Jsvrcek/ICS/CalendarStream.php
+++ b/src/Jsvrcek/ICS/CalendarStream.php
@@ -39,6 +39,8 @@ class CalendarStream
      */
     public function addItem($item);
     {
+	$line_breaks=array("\r\n","\n", "\r");
+	$item=str_replace($line_breaks,'\n',$item);
         $this->stream .= wordwrap($item,70,Constants::CRLF.' ',true).Constants::CRLF;
         
         return $this;

--- a/src/Jsvrcek/ICS/CalendarStream.php
+++ b/src/Jsvrcek/ICS/CalendarStream.php
@@ -37,7 +37,7 @@ class CalendarStream
      * @param string $item
      * @return CalendarStream
      */
-    public function addItem($item);
+    public function addItem($item)
     {
 	$line_breaks=array("\r\n","\n", "\r");
 	$item=str_replace($line_breaks,'\n',$item);

--- a/src/Jsvrcek/ICS/CalendarStream.php
+++ b/src/Jsvrcek/ICS/CalendarStream.php
@@ -37,32 +37,9 @@ class CalendarStream
      * @param string $item
      * @return CalendarStream
      */
-    public function addItem($item)
+    public function addItem($item);
     {
-        //get number of bytes
-        $length = strlen($item);
-        
-        $block = '';
-        
-        if ($length > 75)
-        {
-            $start = 0;
-            
-            while ($start < $length)
-            {
-                $block .= mb_strcut($item, $start, self::LINE_LENGTH, 'UTF-8');
-                $start = $start + self::LINE_LENGTH;
-                
-                //add space if not last line
-                if ($start < $length) $block .= Constants::CRLF.' ';
-            }
-        }
-        else
-        {
-            $block = $item;
-        }
-    
-        $this->stream .= $block.Constants::CRLF;
+        $this->stream .= wordwrap($item,70,Constants::CRLF.' ',true).Constants::CRLF;
         
         return $this;
     }


### PR DESCRIPTION
using the php wordwrap function, i simplified the addItem method. Other changes are due to former mixed-type line breaks.
Also, rfc 5545 requires line breaks in the texts to be encoded, which i implemented in the second commit.