### PR TITLE
Ignore phpunit.xml locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .idea
 vendor
 composer.lock
+phpunit.xml


### PR DESCRIPTION
This will allow developers to use local phpunit.xml files without worrying about the version control.