### PR TITLE
Fix $item cutting in CalendarStream->addItem()

### DIFF
--- a/src/CalendarStream.php
+++ b/src/CalendarStream.php
@@ -63,8 +63,9 @@ class CalendarStream
             $start = 0;
             
             while ($start < $length) {
-                $block .= mb_strcut($item, $start, self::LINE_LENGTH, 'UTF-8');
-                $start = $start + self::LINE_LENGTH;
+                $cut = mb_strcut($item, $start, self::LINE_LENGTH, 'UTF-8');
+                $block .= $cut;
+                $start = $start + strlen($cut);
                 
                 //add space if not last line
                 if ($start < $length) {


### PR DESCRIPTION
When the mb_strcut happens to cut through a multibyte character at the end of the cutting length, it ommits the leading byte of that character resulting in less than self::LINE_LENGTH bytes added to the $block. Number added to $start should not be constant. Next cycle, the next mb_strcut also cuts through the same multibyte character, this time including it and doing a shift back in the $item. The next cycle, one single byte character is ommited in the output.

To recreate this behavoir, create $item like this:
 69 single byte characters
 1 multibyte character
 72+ single byte characters (to see the character missing)