### PR TITLE
Fix VTIMEZONE to work in Outlook when using CalendarExport::setDateTimeFormat

### DIFF
--- a/src/CalendarExport.php
+++ b/src/CalendarExport.php
@@ -110,13 +110,7 @@ class CalendarExport
                 $varName = ($transition['isdst']) ? 'daylightSavings' : 'standard';
 
                 ${$varName}['exists'] = true;
-                if ($this->dateTimeFormat === 'local') {
-                    ${$varName}['start'] = ':' . $this->formatter->getFormattedDateTime(new \DateTime($transition['time']));
-                } else if ($this->dateTimeFormat === 'utc') {
-                    ${$varName}['start'] = ':' . $this->formatter->getFormattedUTCDateTime(new \DateTime($transition['time']));
-                } else if ($this->dateTimeFormat == 'local-tz') {
-                    ${$varName}['start'] = ';' . $this->formatter->getFormattedDateTimeWithTimeZone(new \DateTime($transition['time']));
-                }
+                ${$varName}['start'] = ':' . $this->formatter->getFormattedDateTime(new \DateTime($transition['time']));
 
                 ${$varName}['offsetTo'] = $this->formatter->getFormattedTimeOffset($transition['offset']);
 


### PR DESCRIPTION
#36 adds CalendarExport::setDateTimeFormat, which you can use to make calendars play nice with Outlook.  When, however, you set it to "local-tz" mode, that causes ALL datetimes to be rendered that way, which, in the VTIMEZONE block, outlook barfs.

Output before:
![image](https://user-images.githubusercontent.com/1727656/63546947-960adc00-c4f0-11e9-9e7e-550d0347dbaf.png)

This causes:
![image](https://user-images.githubusercontent.com/1727656/63546967-a458f800-c4f0-11e9-932e-9828609896a3.png)

Output after:
![image](https://user-images.githubusercontent.com/1727656/63547032-d9fde100-c4f0-11e9-949c-16947c7da011.png)

This reverts the datetime changes when rendering the VTIMEZONE block, making Outlook show only ponies and unicorns!