### PR TITLE
Added support for relative alarm triggers.

### DIFF
--- a/src/CalendarExport.php
+++ b/src/CalendarExport.php
@@ -260,7 +260,7 @@ class CalendarExport
                 foreach ($event->getAlarms() as $alarm) {
                     //basic requirements for all types of alarm
                     $this->stream->addItem('BEGIN:VALARM')
-                            ->addItem('TRIGGER;VALUE=DATE-TIME:'.$this->formatter->getFormattedUTCDateTime($alarm->getTrigger()))
+                            ->addItem($this->formatTrigger($alarm->getTrigger()))
                             ->addItem('ACTION:'.$alarm->getAction());
 
                     //only handle repeats if both repeat and duration are set
@@ -350,5 +350,13 @@ class CalendarExport
     {
         $this->calendars[] = $cal;
         return $this;
+    }
+
+    private function formatTrigger($trigger) {
+        if ($trigger instanceof \DateInterval) {
+            return 'TRIGGER:-' . $this->formatter->getFormattedDateInterval($trigger);
+        } else {
+            return 'TRIGGER;VALUE=DATE-TIME:'.$this->formatter->getFormattedUTCDateTime($trigger);
+        }
     }
 }

--- a/src/Model/CalendarAlarm.php
+++ b/src/Model/CalendarAlarm.php
@@ -22,7 +22,7 @@ class CalendarAlarm
      * Only absolute trigger times are supported.
      * @todo Support RELATED, DTSTART, and DTEND.
      *
-     * @var \DateTime
+     * @var \DateTime|\DateInterval
      */
     private $trigger;
 
@@ -96,7 +96,7 @@ class CalendarAlarm
     }
 
     /**
-     * @return \DateTime
+     * @return \DateTime|\DateInterval
      */
     public function getTrigger()
     {
@@ -104,7 +104,7 @@ class CalendarAlarm
     }
 
     /**
-     * @param \DateTime $trigger
+     * @param \DateTime|\DateInterval $trigger
      * @return \Jsvrcek\ICS\Model\CalendarAlarm
      */
     public function setTrigger($trigger)


### PR DESCRIPTION
Hi!

I needed support for relative triggers like

`TRIGGER:-PT30M`

I have added it, you can now use e.g.

```
$alarm = new \Jsvrcek\ICS\Model\CalendarAlarm();
$alarm->setAction("DISPLAY");
$alarm->setTrigger(new DateInterval("PT30M"));

```
to create such an alarm. Trigger will support DateTime and DateInterval and create the appropriate TRIGGER lines for each.
