### PR TITLE
Specifying the DTSTART time of a time zone in the time zone definitio…

### DIFF
--- a/src/CalendarExport.php
+++ b/src/CalendarExport.php
@@ -119,7 +119,7 @@ class CalendarExport
                 } else if ($this->dateTimeFormat === 'utc') {
                     ${$varName}['start'] = ':' . $this->formatter->getFormattedUTCDateTime(new \DateTime($transition['time']));
                 } else if ($this->dateTimeFormat == 'local-tz') {
-                    ${$varName}['start'] = ';' . $this->formatter->getFormattedDateTimeWithTimeZone(new \DateTime($transition['time']));
+                    ${$varName}['start'] = ':' . $this->formatter->getFormattedUTCDateTime(new \DateTime($transition['time']));
                 }
 
                 ${$varName}['offsetTo'] = $this->formatter->getFormattedTimeOffset($transition['offset']);


### PR DESCRIPTION
…n block as UTC instead of using a TZID to make it compatible with Google Calendar.