### PR TITLE
Fix VTIMEZONE DTSTART format and TZOFFSETFROM calculation

### DIFF
--- a/src/CalendarExport.php
+++ b/src/CalendarExport.php
@@ -114,13 +114,6 @@ class CalendarExport
                 $varName = ($transition['isdst']) ? 'daylightSavings' : 'standard';
 
                 ${$varName}['exists'] = true;
-                if ($this->dateTimeFormat === 'local') {
-                    ${$varName}['start'] = ':' . $this->formatter->getFormattedDateTime(new \DateTime($transition['time']));
-                } else if ($this->dateTimeFormat === 'utc') {
-                    ${$varName}['start'] = ':' . $this->formatter->getFormattedUTCDateTime(new \DateTime($transition['time']));
-                } else if ($this->dateTimeFormat == 'local-tz') {
-                    ${$varName}['start'] = ';' . $this->formatter->getFormattedDateTimeWithTimeZone(new \DateTime($transition['time']));
-                }
 
                 ${$varName}['offsetTo'] = $this->formatter->getFormattedTimeOffset($transition['offset']);
 
@@ -131,6 +124,10 @@ class CalendarExport
                 $offset = $tzDate->getOffset();
 
                 ${$varName}['offsetFrom'] = $this->formatter->getFormattedTimeOffset($offset);
+
+                //use previous offset to get local transition start time
+                $transitionStartLocal = (new \DateTime($transition['time']))->modify($offset.' seconds');
+                ${$varName}['start'] = ':' . $this->formatter->getFormattedDateTime($transitionStartLocal);
             }
 
             $this->stream->addItem('TZID:'.$tz->getName());

--- a/src/CalendarExport.php
+++ b/src/CalendarExport.php
@@ -118,7 +118,7 @@ class CalendarExport
                 ${$varName}['offsetTo'] = $this->formatter->getFormattedTimeOffset($transition['offset']);
 
                 //get previous offset
-                $previousTimezoneObservance = $transition['ts'] - 100;
+                $previousTimezoneObservance = $transition['ts'] - 3700;
                 $tzDate = new \DateTime('now', $tz);
                 $tzDate->setTimestamp($previousTimezoneObservance);
                 $offset = $tzDate->getOffset();


### PR DESCRIPTION
Fix for Issue #53 

- Remove inline TZID from VTIMEZONE -> DTSTART for compatibility with Google and adherence to https://tools.ietf.org/html/rfc5545#page-66.
Old: `DTSTART;TZID=+00:00:20201101T090000`
Fixed: `DTSTART:20201101T090000`
- Set DTSTART to local time as stated in https://tools.ietf.org/html/rfc5545#page-66 ("DTSTART in this usage must be specified as a date with a local time value"). Since getTransitions() returns UTC times, use the previous offset to calculate local time.
Old: `20201101T090000` (Los Angeles 2am transition time, UTC)
Fixed: `20201101T020000` (Los Angeles 2am transition time, local)
- Update the TZOFFSETFROM calculation to look back more than 1 hour to get the previous timezone offset. In some cases, the previous offset was not different from the new offset, possibly due to the 100-second look back putting it in the same offset due to the transition.

Old:
```
TZID:Australia/Sydney
BEGIN:STANDARD
DTSTART:20200405T020000
TZOFFSETTO:+1000
TZOFFSETFROM:+1000
```
Fixed:
```
TZID:Australia/Sydney
BEGIN:STANDARD
DTSTART:20200405T030000
TZOFFSETTO:+1000
TZOFFSETFROM:+1100
```