### PR TITLE
Update CalendarExport.php

### DIFF
--- a/src/CalendarExport.php
+++ b/src/CalendarExport.php
@@ -209,7 +209,8 @@ class CalendarExport
 
                 $this->stream
                     ->addItem('SUMMARY:'.$event->getSummary())
-                    ->addItem('DESCRIPTION:'.$this->formatter->getEscapedText($event->getDescription()));
+                    ->addItem('DESCRIPTION:'.$this->formatter->getEscapedText($event->getDescription()))
+                    ->addItem('X-ALT-DESC;FMTTYPE=text/html:'.$this->formatter->getEscapedText($event->getDescription()));
 
                 if ($event->getClass()) {
                     $this->stream->addItem('CLASS:'.$event->getClass());


### PR DESCRIPTION
Html Tags for Calendar Description in Outlook enabled. Striping Tags needs to be done before setting Description.